### PR TITLE
added conf-bap-llvm dependency to local opam file

### DIFF
--- a/opam/opam
+++ b/opam/opam
@@ -11,6 +11,8 @@ build: [
   ["./configure"
   "--prefix=%{prefix}%"
   "--with-cxx=`which clang++`"
+  "--with-llvm-version={conf-bap-llvm:package-version}" {conf-bap-llvm:installed}
+  "--with-llvm-config={conf-bap-llvm:config}" {conf-bap-llvm:installed}
   "--mandir=%{man}%"
   "--enable-everything"
   "--enable-tests"
@@ -209,6 +211,7 @@ depends: [
     "zarith"
     "uuidm"
     "piqi" {>= "0.7.4"}
+    "conf-bap-llvm" {>= "1.1"}
 ]
 
 


### PR DESCRIPTION
The reason is `bap-testsuite`  failed to build bap because `travis` tries to use `llvm-3.9`
